### PR TITLE
fix: direct users to the correct logfile location

### DIFF
--- a/crates/tattoy/src/main.rs
+++ b/crates/tattoy/src/main.rs
@@ -56,11 +56,12 @@ async fn main() -> Result<()> {
     color_eyre::install()?;
     let state_arc = shared_state::SharedState::init().await?;
     let result = run::run(&std::sync::Arc::clone(&state_arc)).await;
+    let logpath = state_arc.config.read().await.log_path.clone();
     tracing::debug!("Tattoy is exiting 🙇");
     if let Err(error) = result {
         tracing::error!("{error:?}");
         eprintln!("Error: {error}");
-        eprintln!("See `./tattoy.log` for more details");
+        eprintln!("See {logpath:?} for more details");
     }
     Ok(())
 }


### PR DESCRIPTION
I tried to run `cargo run --release -- --capture-palette` but, because of my system, the command failed. The command helpfully noted that there was a logfile but the path it recommended was a hardcoded `./tattoy.log`. I found the log file at `$XDG_STATE_DIR/tattoy/tattoy.log` instead (exactly where the README.md pointed me to).

This patch changes the hardcoded `./tattoy.log` to the path to the logfile as known to the config. On my system, it now prints `See "/home/tmckee/.local/state/tattoy/tattoy.log" for more details`.