### PR TITLE
Evaluate XDG_STATE_HOME to show log path

### DIFF
--- a/crates/tattoy/src/main.rs
+++ b/crates/tattoy/src/main.rs
@@ -58,9 +58,17 @@ async fn main() -> Result<()> {
     let result = run::run(&std::sync::Arc::clone(&state_arc)).await;
     tracing::debug!("Tattoy is exiting 🙇");
     if let Err(error) = result {
-        tracing::error!("{error:?}");
-        eprintln!("Error: {error}");
-        eprintln!("See `./tattoy.log` for more details");
+        match std::env::var("XDG_STATE_HOME") {
+            Ok(data) => {
+                let log_file = format!("{data}/tattoy.log");
+                tracing::error!("Error: {error:?}");
+                eprintln!("See `{log_file}` for more details");
+            }
+            Err(_) => {
+                tracing::error!("Error: {error:?}");
+                eprintln!("The environment variable XDG_STATE_HOME is not set to a valid path");
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
I had a very strange heisenberg bug. On very first initial launch of --capture-pallette tattoy crashed and showed me the wrong location of the log  #31 . I saw that it was hard coded and therefore could not know my system.

In this branch I tried to adhere to all of clippy's requirement and make a dynamic right evaluation of XDG_STATE_HOME. Unfortunately I couldn't trigger the same error again from initial launch. No matter if I did a cargo clean, or rm -r ~/.cargo or a full delete of config and state directories.

I would prefer to evaluate the initial bug to prove my branch changes, but I leave it up to your experience. Please correct my approach in any way necessary, so that I can learn to write better code in the future.