### PR TITLE
feat(ci): support running Rust workflow manually

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Rust
 
+# Note: when forking on GitHub, workflows are disabled-by-default; the jobs
+# won't run when pushing to the fork and there won't be a button to run
+# anything manually. Owners of the fork can, through the website, re-enable
+# these workflows to run as specified here.
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
This PR makes it easier for people to run CI jobs in a fork of tombh/tattoy by marking the CI jobs as 'let people run this manually'.

They'll have to explicitly enable actions in their fork before the button will show up for them so I made reference to that in a comment. After that, they still have control over what runs in their fork with some more repo-specific github settings. The docs are pretty good about what can/can't be done and how to go about doing it.

Not for this PR but the docs [did recommend](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions:~:text=Pin%20actions%20to%20a%20full%20length%20commit%20SHA) referring to third-party actions by hash instead of by tag. It does mean that updating action versions isn't so automagic anymore (though dependabot can help with it). I'll leave it to @tombh to decide if they want to pin hashes or not.