### PR TITLE
Custom config path and logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,8 @@ It would be really useful if you could try the following:
 * Change numbers in the config, like `saturation`, `opacity`, etc and see if they live update in the terminal.
 * Find new shaders on https://www.shadertoy.com to try. Currently you can only use single file shaders that _don't_ use the `iChannel0` box (see underneath the code on the shader's webpage). The most interesting shaders will be the ones that are interactive because the terminal cursor is currently providing the `iMouse` value in the shaders.
 
-Logs go to: `$XDG_STATE_DIR/tattoy/tattoy.log` (path configurable in the config file).
+## Debugging
+* Set `log_level = "trace"` in `$XDG_CONFIG_DIR/tattoy/tattoy.toml`
+* Default log path is `$XDG_STATE_DIR/tattoy/tattoy.log`.
+* Log path can be changed with `log_path = "/tmp/tattoy.log"` in `$XDG_CONFIG_DIR/tattoy/tattoy.toml`
+* Or log path can be changed per-instance with the `--log-path` CLI argument.

--- a/crates/shadow_terminal/src/steppable_terminal.rs
+++ b/crates/shadow_terminal/src/steppable_terminal.rs
@@ -665,7 +665,7 @@ mod test {
 
         // TODO: this should work pretty easily with Powershell, it's just a matter of finding the
         // right commands.
-        let command = "echo -en \"\\E[6n\"; read -sdR CURPOS; echo ${CURPOS#*[}";
+        let command = "sleep 0.1; echo -en \"\\E[6n\"; read -sdR CURPOS; echo ${CURPOS#*[}";
 
         stepper.send_command(command).unwrap();
 

--- a/crates/tattoy/default_config.toml
+++ b/crates/tattoy/default_config.toml
@@ -7,8 +7,8 @@ term = "xterm-256color"
 # `SHELL` env var.
 # command = "/usr/bin/zsh"
 
-# The log level, one of: "error", "warn", "info", "debug", "trace"
-log_level = "debug"
+# The log level, one of: "off", "error", "warn", "info", "debug", "trace"
+log_level = "off"
 # The path to the log file. Defaults to your OS's `XDG_STATE_DIR`.
 # See: https://specifications.freedesktop.org/basedir-spec/latest/
 # log_path = ""

--- a/crates/tattoy/src/cli_args.rs
+++ b/crates/tattoy/src/cli_args.rs
@@ -1,5 +1,8 @@
 //! All the CLI arguments for Tattoy
 
+/// The default name of the main config file.
+pub const DEFAULT_CONFIG_FILE_NAME: &str = "tattoy.toml";
+
 /// Simple program to greet a person
 #[derive(clap::Parser, Debug, Clone)]
 #[command(version, about, long_about = "Tattoy argument description")]
@@ -29,6 +32,15 @@ pub struct CliArgs {
     /// files.
     #[arg(long, value_name = "Path to config directory")]
     pub config_dir: Option<std::path::PathBuf>,
+
+    /// Override the default Tattoy config _file_. The same default config directory is used, so the
+    /// palette and shader files are the same.
+    #[arg(
+        long,
+        default_value = DEFAULT_CONFIG_FILE_NAME,
+        value_name = "Path to the main Tattoy config file"
+    )]
+    pub main_config: std::path::PathBuf,
 
     /// Path to the log file, overrides the setting in config.
     #[arg(long, value_name = "Path to log file")]

--- a/crates/tattoy/src/cli_args.rs
+++ b/crates/tattoy/src/cli_args.rs
@@ -6,10 +6,9 @@ pub const DEFAULT_CONFIG_FILE_NAME: &str = "tattoy.toml";
 /// Simple program to greet a person
 #[derive(clap::Parser, Debug, Clone)]
 #[command(version, about, long_about = "Tattoy argument description")]
-#[non_exhaustive]
-pub struct CliArgs {
+pub(crate) struct CliArgs {
     /// Name of the Tattoy(s) to use.
-    #[arg(short, long("use"))]
+    #[arg(long("use"))]
     pub enabled_tattoys: Vec<String>,
 
     // TODO: Currently only usesd by the e2e tests. I'd rather have a more general purpose flag
@@ -17,7 +16,7 @@ pub struct CliArgs {
     // `config.minimap.enabled = false`.
     //
     /// The command to start Tattoy with. Default to `$SHELL`.
-    #[arg(short, long)]
+    #[arg(long)]
     pub command: Option<String>,
 
     /// Use image capture to detect the true colour values of the terminal's palette.
@@ -33,7 +32,7 @@ pub struct CliArgs {
     #[arg(long, value_name = "Path to config directory")]
     pub config_dir: Option<std::path::PathBuf>,
 
-    /// Override the default Tattoy config _file_. The same default config directory is used, so the
+    /// Override the default Tattoy config *file*. The same default config directory is used, so the
     /// palette and shader files are the same.
     #[arg(
         long,
@@ -45,4 +44,8 @@ pub struct CliArgs {
     /// Path to the log file, overrides the setting in config.
     #[arg(long, value_name = "Path to log file")]
     pub log_path: Option<std::path::PathBuf>,
+
+    /// Verbosity of logs
+    #[arg(long, value_name = "Level to log at")]
+    pub log_level: Option<crate::config::LogLevel>,
 }

--- a/crates/tattoy/src/config.rs
+++ b/crates/tattoy/src/config.rs
@@ -14,6 +14,24 @@ static EXAMPLE_SHADER: &str = include_str!("tattoys/shaders/point_lights.glsl");
 /// The name of the directory where shader files are kept.
 const SHADER_DIRECTORY_NAME: &str = "shaders";
 
+/// The valid log levels. Based on our `tracing` crate.
+#[derive(serde::Serialize, serde::Deserialize, clap::ValueEnum, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LogLevel {
+    /// Error
+    Error,
+    /// Warnings
+    Warn,
+    /// Info
+    Info,
+    /// Debug
+    Debug,
+    /// Trace
+    Trace,
+    /// No logging
+    Off,
+}
+
 /// Managing user config.
 #[expect(
     clippy::unsafe_derive_deserialize,
@@ -29,7 +47,7 @@ pub(crate) struct Config {
     /// `SHELL` env variable.
     pub command: String,
     /// The maximum log level
-    pub log_level: String,
+    pub log_level: LogLevel,
     /// The location of the log file.
     pub log_path: std::path::PathBuf,
     /// Colour grading
@@ -64,7 +82,7 @@ impl Default for Config {
         Self {
             term: "xterm-256color".to_owned(),
             command,
-            log_level: "none".into(),
+            log_level: LogLevel::Off,
             log_path,
             color: Color::default(),
             smokey_cursor: crate::tattoys::smokey_cursor::config::Config::default(),

--- a/crates/tattoy/src/palette/parser.rs
+++ b/crates/tattoy/src/palette/parser.rs
@@ -17,12 +17,6 @@ use color_eyre::Result;
 /// Convenience type for screenshot image.
 type Screenshot = xcap::image::ImageBuffer<xcap::image::Rgba<u8>, std::vec::Vec<u8>>;
 
-/// Reset any OSC colour codes
-const RESET_COLOUR: &str = "\x1b[m";
-
-/// OSC code to clear the terminal
-const CLEAR_SCREEN: &str = "\x1b[2J";
-
 /// A pure blue used for signalling in the our "QR Code" of the palette.
 const PURE_BLUE: &xcap::image::Rgba<u8> = &xcap::image::Rgba::<u8>([0, 0, 255, 255]);
 
@@ -106,7 +100,10 @@ impl Parser {
         Self::print_generic_palette(|palette_index| -> Result<()> {
             let background_colour = palette_index;
             let foreground_colour = palette_index + Self::ROW_SIZE;
-            print!("\x1b[48;5;{background_colour}m\x1b[38;5;{foreground_colour}m▄{RESET_COLOUR}");
+            print!(
+                "\x1b[48;5;{background_colour}m\x1b[38;5;{foreground_colour}m▄{}",
+                crate::utils::RESET_COLOUR
+            );
             Ok(())
         })?;
 
@@ -142,14 +139,20 @@ impl Parser {
     /// Use the UTF-8 half block trick to print 2 colours in one cell.
     pub fn print_2_true_colours_in_1(top: (u8, u8, u8), bottom: (u8, u8, u8)) {
         print!(
-            "\x1b[48;2;{};{};{}m\x1b[38;2;{};{};{}m▄{RESET_COLOUR}",
-            top.0, top.1, top.2, bottom.0, bottom.1, bottom.2,
+            "\x1b[48;2;{};{};{}m\x1b[38;2;{};{};{}m▄{}",
+            top.0,
+            top.1,
+            top.2,
+            bottom.0,
+            bottom.1,
+            bottom.2,
+            crate::utils::RESET_COLOUR
         );
     }
 
     /// Take a screenshot of the current monitor.
     fn take_screenshot() -> Result<Screenshot> {
-        println!("{CLEAR_SCREEN}");
+        println!("{}", crate::utils::CLEAR_SCREEN);
 
         Self::print_native_palette()?;
 

--- a/crates/tattoy/src/run.rs
+++ b/crates/tattoy/src/run.rs
@@ -158,8 +158,13 @@ pub(crate) fn broadcast_protocol_end(protocol_tx: &tokio::sync::broadcast::Sende
 /// Prepare the application to start.
 async fn setup(state: &std::sync::Arc<SharedState>) -> Result<CliArgs> {
     let cli_args = CliArgs::parse();
+
+    let mut main_config_file = state.main_config_file.write().await;
+    (*main_config_file).clone_from(&cli_args.main_config);
+    drop(main_config_file);
+
     crate::config::Config::setup_directory(cli_args.config_dir.clone(), state).await?;
-    crate::config::Config::update_shared_state(state).await?;
+    crate::config::Config::load_config_into_shared_state(state).await?;
 
     setup_logging(cli_args.clone(), state).await?;
 

--- a/crates/tattoy/src/shared_state.rs
+++ b/crates/tattoy/src/shared_state.rs
@@ -51,6 +51,8 @@ pub(crate) struct SharedState {
     /// A counter for every change to the underlying PTY output. Useful for triggering behaviour on
     /// screen state changes.
     pub pty_sequence: tokio::sync::RwLock<usize>,
+    /// Is the application logging?
+    pub is_logging: tokio::sync::RwLock<bool>,
 }
 
 impl SharedState {

--- a/crates/tattoy/src/shared_state.rs
+++ b/crates/tattoy/src/shared_state.rs
@@ -26,12 +26,12 @@ pub struct TTYSize {
 pub(crate) struct SharedState {
     /// Location of the config directory.
     pub config_path: tokio::sync::RwLock<std::path::PathBuf>,
+    /// Name of the main config file.
+    pub main_config_file: tokio::sync::RwLock<std::path::PathBuf>,
     /// User config
     pub config: tokio::sync::RwLock<crate::config::Config>,
     /// Just the size of the user's terminal. All the tattoys and shadow TTY should follow this
     pub tty_size: tokio::sync::RwLock<TTYSize>,
-
-    // TODO: rename to `shadow_alternate_screen`?
     /// This is a view onto the active screen of the shadow terminal. It's what you would see if
     /// you had some kind of VNC viewer, let's say.
     pub shadow_tty_screen: tokio::sync::RwLock<termwiz::surface::Surface>,

--- a/crates/tattoy/src/utils.rs
+++ b/crates/tattoy/src/utils.rs
@@ -7,3 +7,12 @@ pub const NEWLINE: &str = "\n";
 #[cfg(target_os = "windows")]
 /// The Windows newline
 pub const NEWLINE: &str = "\r\n";
+
+/// Reset any OSC colour codes
+pub const RESET_COLOUR: &str = "\x1b[m";
+
+/// OSC code to clear the terminal screen.
+pub const CLEAR_SCREEN: &str = "\x1b[2J";
+
+/// OSC code to reset the terminal screen.
+pub const RESET_SCREEN: &str = "\x1bc";

--- a/crates/tests/e2e_tests.rs
+++ b/crates/tests/e2e_tests.rs
@@ -73,8 +73,8 @@ mod e2e {
             clippy::option_if_let_else,
             reason = "In this case `match` reads better that `map_or`"
         )]
-        let rust_log_filters = match std::env::var_os("RUST_LOG") {
-            Some(value) => format!("RUST_LOG={value:?}"),
+        let rust_log_filters = match std::env::var_os("TATTOY_LOG") {
+            Some(value) => format!("TATTOY_LOG={value:?}"),
             None => String::new(),
         };
 


### PR DESCRIPTION
* Allows starting Tattoy from the same config directory but using a different maing config file.
* Log filter is now `TATTOY_LOG` instead of `RUST_LOG`.
* Logging is now disabled by default.
* Log level can be overridden with a CLI arg.
* Screen is cleared, very clean, on exit.
* Always show log path on exit if logging is enabled.