### PR TITLE
Performance: some low-hanging fruit

### DIFF
--- a/crates/shadow_terminal/src/pty.rs
+++ b/crates/shadow_terminal/src/pty.rs
@@ -198,7 +198,7 @@ impl PTY {
         tracing::debug!("Starting PTY reader loop");
         #[expect(
             clippy::integer_division_remainder_used,
-            reason = "`tokio::select! generates this.`"
+            reason = "`tokio::select!` generates this."
         )]
         loop {
             tokio::select! {

--- a/crates/shadow_terminal/src/shadow_terminal.rs
+++ b/crates/shadow_terminal/src/shadow_terminal.rs
@@ -189,7 +189,7 @@ impl ShadowTerminal {
         tracing::debug!("Starting Shadow Terminal main loop");
         #[expect(
             clippy::integer_division_remainder_used,
-            reason = "`tokio::select! generates this.`"
+            reason = "`tokio::select!` generates this."
         )]
         loop {
             tokio::select! {

--- a/crates/shadow_terminal/src/steppable_terminal.rs
+++ b/crates/shadow_terminal/src/steppable_terminal.rs
@@ -214,7 +214,11 @@ impl SteppableTerminal {
             let result = self.shadow_terminal.channels.output_rx.try_recv();
             match result {
                 Ok(bytes) => {
-                    Box::pin(self.shadow_terminal.handle_pty_output(&bytes))
+                    self.shadow_terminal
+                        .accumulated_pty_output
+                        .append(&mut bytes.to_vec());
+
+                    Box::pin(self.shadow_terminal.handle_pty_output())
                         .await
                         .with_whatever_context(|err| {
                             format!("Couldn't handle PTY output: {err:?}")

--- a/crates/tattoy/default_config.toml
+++ b/crates/tattoy/default_config.toml
@@ -13,6 +13,9 @@ log_level = "off"
 # See: https://specifications.freedesktop.org/basedir-spec/latest/
 # log_path = ""
 
+# The target frame rate
+frame_rate = 30
+
 [color]
 saturation = 0.0
 brightness = 0.0

--- a/crates/tattoy/src/tattoys/minimap.rs
+++ b/crates/tattoy/src/tattoys/minimap.rs
@@ -8,7 +8,7 @@ use shadow_terminal::output::SurfaceKind;
 use super::tattoyer::Tattoyer;
 
 /// User-configurable settings for the minimap
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug, Clone)]
 #[serde(default)]
 pub(crate) struct Config {
     /// Enable/disable the minimap

--- a/crates/tattoy/src/tattoys/shaders/main.rs
+++ b/crates/tattoy/src/tattoys/shaders/main.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::{ContextCompat as _, Result};
 use crate::tattoys::tattoyer::Tattoyer;
 
 /// All the user config for the shader tattoy.
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug, Clone)]
 #[serde(default)]
 pub(crate) struct Config {
     /// Enable/disable the shaders on and off

--- a/crates/tattoy/src/tattoys/smokey_cursor/config.rs
+++ b/crates/tattoy/src/tattoys/smokey_cursor/config.rs
@@ -1,7 +1,7 @@
 //! All the variables that can be configured for the simulation
 
 /// All the config for the simulation
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug, Clone)]
 #[serde(default)]
 #[non_exhaustive]
 pub struct Config {


### PR DESCRIPTION
1. Previously when many shader frames were being rendered on a large terminal, the renderer would build up a backlog and not be able to render user input very quickly. The change here allows dropping tattoy frames when the backlog gets too big, thus allowing PTY output to be rendered as soon as possible.
Also adds:
    * User-configurable frame rate for tattoys. Hot reloading of course!
    * A new protocol message that broadcasts the config to all tattoys.

2. Previously each PTY output would trigger its own broadcastable surface
output. But because the PTY output payloads are fixed at 4kb, then
often, on bigger terminals, the surface broadcast would be unnesecarry
and inefficient. Also I think the partial PTY outputs were causing the
cursor to be sporadically rendered in the middle of the screen.
