### PR TITLE
fix(plugins): break listener loop on exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-
 [workspace]
 resolver = "2"
 members = [


### PR DESCRIPTION
Not only is this just better cleanup but it also prevents an issue where the logs get spammed with GBs of lines when the plugin unexpectedly exits.

Fixes #57 