### PR TITLE
feat: background commands or the "Second Terminal"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         run: sudo apt-get install libxcb1-dev libdbus-1-dev
       - if: matrix.os == 'macos-latest'
         name: Install MacOS dependencies
-        run: brew install bash nano
+        run: brew install bash nano watch
       - if: matrix.os == 'windows-latest'
         name: Install Windows package manager
         uses: crazy-max/ghaction-chocolatey@v3

--- a/crates/tattoy/default_config.toml
+++ b/crates/tattoy/default_config.toml
@@ -39,6 +39,12 @@ opacity = 0.75
 # Tattoy's config directory.
 path = "shaders/point_lights.glsl"
 
+[bg_command]
+enabled = false
+opacity = 0.75
+layer = -5
+command = ["echo", "Hello World"]
+
 [keybindings]
 # Whether Tattoy renders anything apart from the TTY. They TTY is always rendered,
 # so toggling this will disable all tattoys, effects, eye-candy, etc.

--- a/crates/tattoy/src/config/main.rs
+++ b/crates/tattoy/src/config/main.rs
@@ -64,6 +64,8 @@ pub(crate) struct Config {
     pub minimap: crate::tattoys::minimap::Config,
     /// The shaders
     pub shader: crate::tattoys::shaders::main::Config,
+    /// Background command
+    pub bg_command: crate::tattoys::bg_command::Config,
 }
 
 impl Default for Config {
@@ -97,6 +99,7 @@ impl Default for Config {
             plugins: Vec::default(),
             minimap: crate::tattoys::minimap::Config::default(),
             shader: crate::tattoys::shaders::main::Config::default(),
+            bg_command: crate::tattoys::bg_command::Config::default(),
         }
     }
 }
@@ -342,12 +345,12 @@ impl Config {
 
     /// Load the terminal's palette as true colour values.
     pub async fn load_palette(
-        state: &std::sync::Arc<crate::shared_state::SharedState>,
+        state: std::sync::Arc<crate::shared_state::SharedState>,
     ) -> Result<Option<crate::palette::converter::Palette>> {
-        let path = crate::palette::parser::Parser::palette_config_path(state).await;
+        let path = crate::palette::parser::Parser::palette_config_path(&state).await;
         if path.exists() {
             tracing::info!("Loading the terminal palette's true colours from config");
-            let data = std::fs::read_to_string(path)?;
+            let data = tokio::fs::read_to_string(path).await?;
             let map = toml::from_str::<crate::palette::converter::PaletteHashMap>(&data)?;
             let palette = crate::palette::converter::Palette { map };
             Ok(Some(palette))

--- a/crates/tattoy/src/main.rs
+++ b/crates/tattoy/src/main.rs
@@ -32,12 +32,12 @@ pub mod utils;
 
 /// This is where all the various tattoys are kept
 pub mod tattoys {
+    pub mod bg_command;
     pub mod minimap;
     pub mod plugins;
     pub mod random_walker;
     pub mod scrollbar;
     pub mod tattoyer;
-    pub mod utils;
 
     /// Shadertoy-like shaders
     pub mod shaders {

--- a/crates/tattoy/src/surface.rs
+++ b/crates/tattoy/src/surface.rs
@@ -31,6 +31,8 @@ pub(crate) struct Surface {
     /// layering value below 0 will make the tattoy appear below the user's terminal content,
     /// and any value above 0 will make it appear above the user's terminal content.
     pub layer: i16,
+    /// The transparency of the surface.
+    pub opacity: f32,
     /// A surface of terminal cells
     pub surface: termwiz::surface::Surface,
 }
@@ -38,12 +40,13 @@ pub(crate) struct Surface {
 impl Surface {
     /// Create a Compositor/Tattoy
     #[must_use]
-    pub fn new(id: String, width: usize, height: usize, layer: i16) -> Self {
+    pub fn new(id: String, width: usize, height: usize, layer: i16, opacity: f32) -> Self {
         Self {
             id,
             width,
             height,
             layer,
+            opacity,
             surface: termwiz::surface::Surface::new(width, height),
         }
     }
@@ -197,7 +200,7 @@ mod test {
 
     #[test]
     fn add_new_pixels() {
-        let mut surface = Surface::new("test".into(), 2, 2, -1);
+        let mut surface = Surface::new("test".into(), 2, 2, -1, 1.0);
 
         let cell = &surface.surface.screen_cells()[0][0];
         assert_eq!(cell.str(), " ");
@@ -244,7 +247,7 @@ mod test {
 
     #[test]
     fn add_new_pixel_at_bottom_of_cell() {
-        let mut surface = Surface::new("test".into(), 1, 1, -1);
+        let mut surface = Surface::new("test".into(), 1, 1, -1, 1.0);
 
         surface.add_pixel(0, 1, WHITE).unwrap();
         let cell = &surface.surface.screen_cells()[0][0];
@@ -261,7 +264,7 @@ mod test {
 
     #[test]
     fn add_pixels_on_or_near_other_pixels() {
-        let mut surface = Surface::new("test".into(), 2, 1, -1);
+        let mut surface = Surface::new("test".into(), 2, 1, -1, 1.0);
         surface.add_pixel(0, 0, WHITE).unwrap();
 
         let fg = Surface::make_colour_attribute(WHITE);

--- a/crates/tattoy/src/tattoys/bg_command.rs
+++ b/crates/tattoy/src/tattoys/bg_command.rs
@@ -1,0 +1,160 @@
+//! Run and output a command in the background.
+
+use color_eyre::eyre::Result;
+
+/// User-configurable settings for the background command.
+#[derive(serde::Deserialize, Debug, Clone)]
+pub(crate) struct Config {
+    /// Enable/disable the script
+    pub enabled: bool,
+    /// The transparency of the command output layer
+    pub opacity: f32,
+    /// The layer of the compositor on which the command output is rendered.
+    pub layer: i16,
+    /// The command to run.
+    command: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            opacity: 0.75,
+            layer: -8,
+            command: vec!["echo".to_owned(), "No command provided".to_owned()],
+        }
+    }
+}
+
+/// `BGCommand`
+pub struct BGCommand {
+    /// The base Tattoy struct
+    tattoy: super::tattoyer::Tattoyer,
+    /// An instance of our headless terminal.
+    shadow_terminal: shadow_terminal::active_terminal::ActiveTerminal,
+    /// The user's terminal's colour palette in true colour values.
+    palette: crate::palette::converter::Palette,
+}
+
+impl BGCommand {
+    /// Instatiate
+    async fn new(
+        output_channel: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>,
+        state: std::sync::Arc<crate::shared_state::SharedState>,
+        palette: crate::palette::converter::Palette,
+    ) -> Self {
+        let mut tattoy = super::tattoyer::Tattoyer::new(
+            "bg_command".to_owned(),
+            state.config.read().await.bg_command.layer,
+            state.config.read().await.bg_command.opacity,
+            output_channel,
+        );
+        let tty_size = state.get_tty_size().await;
+        tattoy.set_tty_size(tty_size.width, tty_size.height);
+
+        let command = state.config.read().await.bg_command.command.clone();
+        let _span = tracing::span!(tracing::Level::TRACE, "BGCommand").entered();
+        let shadow_terminal = shadow_terminal::active_terminal::ActiveTerminal::start(
+            shadow_terminal::shadow_terminal::Config {
+                width: tty_size.width,
+                height: tty_size.height,
+                command: command.iter().map(std::convert::Into::into).collect(),
+                scrollback_size: 100,
+                scrollback_step: 1,
+            },
+        );
+
+        tracing::debug!("Started BG Command for: `{}`", command.join(" "));
+        Self {
+            tattoy,
+            shadow_terminal,
+            palette,
+        }
+    }
+
+    /// Our main entrypoint.
+    pub(crate) async fn start(
+        protocol_tx: tokio::sync::broadcast::Sender<crate::run::Protocol>,
+        output: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>,
+        state: std::sync::Arc<crate::shared_state::SharedState>,
+        palette: crate::palette::converter::Palette,
+    ) -> Result<()> {
+        let mut commander = Self::new(output, state, palette).await;
+        let mut protocol = protocol_tx.subscribe();
+
+        #[expect(
+            clippy::integer_division_remainder_used,
+            reason = "This is caused by the `tokio::select!`"
+        )]
+        loop {
+            tokio::select! {
+                Some(pty_output) = commander.shadow_terminal.surface_output_rx.recv() => {
+                    commander.handle_bg_command_output(pty_output).await?;
+                }
+                Ok(message) = protocol.recv() => {
+                    commander.handle_protocol_message(&message)?;
+                    if matches!(message, crate::run::Protocol::End) {
+                        break;
+                    }
+                    commander.tattoy.handle_common_protocol_messages(message)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle output from the headless terminal where the background command was spawned.
+    async fn handle_bg_command_output(
+        &mut self,
+        mut output: shadow_terminal::output::Output,
+    ) -> Result<()> {
+        self.palette.convert_cells_to_true_colour(&mut output);
+        self.tattoy.initialise_surface();
+
+        #[expect(
+            clippy::collapsible_match,
+            clippy::single_match,
+            clippy::wildcard_enum_match_arm,
+            reason = "There's some deep types going on and I think it's easier to read"
+        )]
+        match output {
+            shadow_terminal::output::Output::Diff(surface_diff) => match surface_diff {
+                shadow_terminal::output::SurfaceDiff::Screen(screen_diff) => {
+                    self.tattoy.surface.surface.add_changes(screen_diff.changes);
+                }
+                _ => (),
+            },
+            shadow_terminal::output::Output::Complete(complete_surface) => match complete_surface {
+                shadow_terminal::output::CompleteSurface::Screen(complete_screen) => {
+                    self.tattoy.surface.surface = complete_screen.surface;
+                }
+                _ => (),
+            },
+            _ => (),
+        }
+
+        self.tattoy.send_output().await?;
+
+        Ok(())
+    }
+
+    /// Custom behaviour for protocol messages.
+    fn handle_protocol_message(&self, message: &crate::run::Protocol) -> Result<()> {
+        #[expect(
+            clippy::wildcard_enum_match_arm,
+            reason = "We're ready to add handlers for other messages"
+        )]
+        match message {
+            crate::run::Protocol::Resize { width, height } => {
+                self.shadow_terminal.resize(*width, *height)?;
+            }
+            crate::run::Protocol::End => {
+                self.shadow_terminal.kill()?;
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/tattoy/src/tattoys/minimap.rs
+++ b/crates/tattoy/src/tattoys/minimap.rs
@@ -64,7 +64,7 @@ impl Minimap {
         output_channel: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>,
         state: Arc<crate::shared_state::SharedState>,
     ) -> Self {
-        let tattoy = Tattoyer::new("minimap".to_owned(), 90, output_channel);
+        let tattoy = Tattoyer::new("minimap".to_owned(), 90, 1.0, output_channel);
         Self {
             tattoy,
             scrollback: image::ImageBuffer::default(),

--- a/crates/tattoy/src/tattoys/plugins.rs
+++ b/crates/tattoy/src/tattoys/plugins.rs
@@ -45,6 +45,7 @@ impl Plugin {
         let tattoy = super::tattoyer::Tattoyer::new(
             config.name.clone(),
             config.layer.unwrap_or(DEFAULT_LAYER),
+            1.0,
             output_channel,
         );
         let (parsed_messages_tx, parsed_messages_rx) = tokio::sync::mpsc::channel(16);

--- a/crates/tattoy/src/tattoys/random_walker.rs
+++ b/crates/tattoy/src/tattoys/random_walker.rs
@@ -23,7 +23,7 @@ impl RandomWalker {
     /// Instatiate
     fn new(output_channel: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>) -> Self {
         let tattoy =
-            super::tattoyer::Tattoyer::new("random_walker".to_owned(), -10, output_channel);
+            super::tattoyer::Tattoyer::new("random_walker".to_owned(), -10, 1.0, output_channel);
         let position: Position = (0, 0);
         let colour: crate::surface::Colour = (
             rand::thread_rng().gen_range(0.1..1.0),

--- a/crates/tattoy/src/tattoys/scrollbar.rs
+++ b/crates/tattoy/src/tattoys/scrollbar.rs
@@ -11,7 +11,8 @@ pub(crate) struct Scrollbar {
 impl Scrollbar {
     /// Instantiate
     fn new(output_channel: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>) -> Self {
-        let tattoy = super::tattoyer::Tattoyer::new("scrollbar".to_owned(), 100, output_channel);
+        let tattoy =
+            super::tattoyer::Tattoyer::new("scrollbar".to_owned(), 100, 1.0, output_channel);
         Self { tattoy }
     }
 

--- a/crates/tattoy/src/tattoys/shaders/main.rs
+++ b/crates/tattoy/src/tattoys/shaders/main.rs
@@ -43,7 +43,7 @@ impl Shaders<'_> {
         output_channel: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>,
         state: std::sync::Arc<crate::shared_state::SharedState>,
     ) -> Result<Self> {
-        let tattoy = Tattoyer::new("shaders".to_owned(), -10, output_channel);
+        let tattoy = Tattoyer::new("shaders".to_owned(), -10, 1.0, output_channel);
         let shader_directory = state.config_path.read().await.clone();
         let shader_path = state.config.read().await.shader.path.clone();
         let gpu = super::gpu::GPU::new(shader_directory.join(shader_path)).await?;

--- a/crates/tattoy/src/tattoys/tattoyer.rs
+++ b/crates/tattoy/src/tattoys/tattoyer.rs
@@ -8,6 +8,8 @@ pub(crate) struct Tattoyer {
     pub id: String,
     /// The compositing layer that the tattoy is rendered to. 0 is the PTY screen itself.
     pub layer: i16,
+    /// The transparency of layer.
+    pub opacity: f32,
     /// A channel to send final rendered output.
     pub output_channel: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>,
     /// The surface on which to construct this tattoy's frame.
@@ -33,13 +35,15 @@ impl Tattoyer {
     pub(crate) fn new(
         id: String,
         layer: i16,
+        opacity: f32,
         output_channel: tokio::sync::mpsc::Sender<crate::run::FrameUpdate>,
     ) -> Self {
         Self {
             id: id.clone(),
             layer,
+            opacity,
             output_channel,
-            surface: crate::surface::Surface::new(id, 0, 0, layer),
+            surface: crate::surface::Surface::new(id, 0, 0, layer, opacity),
             width: 0,
             height: 0,
             scrollback: shadow_terminal::output::CompleteScrollback::default(),
@@ -62,6 +66,7 @@ impl Tattoyer {
             self.width.into(),
             self.height.into(),
             self.layer,
+            self.opacity,
         );
     }
 

--- a/crates/tattoy/src/tattoys/utils.rs
+++ b/crates/tattoy/src/tattoys/utils.rs
@@ -1,1 +1,0 @@
-//! Useful common code

--- a/crates/tests/e2e_tests.rs
+++ b/crates/tests/e2e_tests.rs
@@ -362,4 +362,30 @@ mod e2e {
             .await
             .unwrap();
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn background_command() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let conf_dir = temp_dir.into_path();
+        let conf_path = conf_dir.join("tattoy.toml");
+        let mut conf_file = std::fs::File::create(conf_path).unwrap();
+        let config = "
+            [bg_command]
+            enabled = true
+            command = ['bash', '-c', 'watch \"echo testing background command\"']
+            layer = -1
+            opacity = 1.0
+        ";
+        conf_file.write_all(config.as_bytes()).unwrap();
+
+        let mut tattoy = start_tattoy(Some(conf_dir.to_string_lossy().into())).await;
+        tattoy
+            .wait_for_string_at("tattoy", 0, 0, None)
+            .await
+            .unwrap();
+        tattoy
+            .wait_for_string("testing background command", None)
+            .await
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Resolves: #53

Also introduces code to:
* ensure that all tattoys/plugins only start when the user's terminal size is known.
* centralise the opacity of each rendered layer.