### PR TITLE
feat: `iChannel` support for shaders

### DIFF
--- a/crates/tattoy/default_config.toml
+++ b/crates/tattoy/default_config.toml
@@ -25,15 +25,20 @@ saturation = 0.0
 brightness = 0.0
 hue = 0.0
 
-# Automatically increases the foreground colour of text (in all languages) so that it
-# reaches the specified target contrast. It uses the WCAG 2.1 algorithm to define the
-# contrast. For normal text on the web they recommend a minimum contrast of 4.5. Note
-# that only the foreground colour is ever changed (as background colours are used for
-# UIs). The target contrast is searched for by lightening, then darkening and if
-# neither reach the target contrast then the larger of the 2 found contrasts is used.
+# Automatically increases the foreground colour of alphanumeric text. This includes
+# international language characters, but hopefully not common characters used in UI
+# elements such as borders etc. It uses the WCAG 2.1 algorithm to define the contrast.
+# For normal text on the web they recommend a minimum contrast of 4.5. Note that only
+# the foreground colour is ever changed (as background colours are used for UIs). The
+# target contrast is searched for by lightening, then darkening and if neither reach
+# the target contrast then the larger of the 2 found contrasts is used.
 [text_contrast]
 enabled = true
 target_contrast = 2.0
+# When set to false, all text is automatically adjusted, even non-alphanumeric characters
+# like UI border elements etc. The only characters that aren't adjusted are the UTF8
+# half blocks (eg ▀) that are used to render "graphics", as in the shaders for example.
+apply_to_readable_text_only = true
 
 [minimap]
 enabled = false
@@ -45,6 +50,20 @@ max_width = 10
 [shader]
 enabled = false
 opacity = 0.75
+# Whether to render the computed shader from the GPU. The shader pixels can still be
+# used for other purposes such as defining the foreground colour of the terminal's text,
+# see `render_shader_colours_to_text`.
+render = true
+# It can be useful to disable this for certain GUI terminal shaders (such as Ghostty shaders)
+# that also take responsibility for rendering terminal text. Tattoy can only send a crude 
+# representation of terminal text as 2 pixels per character, which is sometimes desirable
+# when the shader uses the terminal to inform the output of the shader, but it can also cause
+# an unnesceray blocky effect when the shader doesn't use the terminal colours.
+upload_tty_as_pixels = true
+# Use each "cell" of the shader to set the corresponding text cell's foreground colour.
+# This is most likely desirable in conjunction with the `render` option, so that the shader
+# is only visible via the terminal's text.
+render_shader_colours_to_text = false
 # Path to a Shadertoy shader on your local filesystem. Is relative to the root of
 # Tattoy's config directory.
 path = "shaders/point_lights.glsl"

--- a/crates/tattoy/src/compositor.rs
+++ b/crates/tattoy/src/compositor.rs
@@ -1,0 +1,99 @@
+//! Composite individual cells into the final renderablsee frame.
+use color_eyre::eyre::{ContextCompat as _, Result};
+
+/// Composite cells together, honouring alpha blending, text and pixels.
+#[derive(Default)]
+pub(crate) struct Compositor;
+
+impl Compositor {
+    /// Get a mutable reference to a cell.
+    pub fn get_cell_mut<'cell>(
+        cells: &'cell mut [&mut [termwiz::cell::Cell]],
+        x: usize,
+        y: usize,
+    ) -> Result<&'cell mut termwiz::cell::Cell> {
+        let x_message = Self::no_coord_error_message("x", x);
+        let y_message = Self::no_coord_error_message("y", y);
+        cells
+            .get_mut(y)
+            .context(y_message)?
+            .get_mut(x)
+            .context(x_message)
+    }
+
+    /// Get a reference to a cell.
+    pub fn get_cell<'cell>(
+        cells: &'cell [&mut [termwiz::cell::Cell]],
+        x: usize,
+        y: usize,
+    ) -> Result<&'cell termwiz::cell::Cell> {
+        let x_message = Self::no_coord_error_message("x", x);
+        let y_message = Self::no_coord_error_message("y", y);
+        cells.get(y).context(y_message)?.get(x).context(x_message)
+    }
+
+    /// The error message when a cell doesn't exist at the provided coordinate.
+    fn no_coord_error_message(axis: &str, coord: usize) -> String {
+        format!("No {axis} coord ({coord}) for cell")
+    }
+
+    /// Simply use the incoming cell's foreground colour for the base cell's foreground
+    /// colour.
+    pub fn composite_fg_colour_only(
+        base_cell: &mut termwiz::cell::Cell,
+        cell_above: &termwiz::cell::Cell,
+    ) {
+        if base_cell.str().chars().all(char::is_whitespace) {
+            return;
+        }
+
+        let mut draft = termwiz::cell::Cell::blank();
+        Self::composite_cells(&mut draft, cell_above, 1.0);
+        let colour = draft.attrs().foreground();
+        base_cell.attrs_mut().set_foreground(colour);
+    }
+
+    /// Composite 2 cells together.
+    pub fn composite_cells(
+        composited_cell: &mut termwiz::cell::Cell,
+        cell_above: &termwiz::cell::Cell,
+        opacity: f32,
+    ) {
+        let character_above = cell_above.str().to_owned();
+        let is_character_above_text = !character_above.is_empty() && character_above != " ";
+        if is_character_above_text {
+            // All this is just because there doesn't seem to be a `cell.set_str("f")` method.
+            let old_background = composited_cell.attrs().background();
+            let old_foreground = composited_cell.attrs().foreground();
+            *composited_cell = cell_above.clone();
+            composited_cell.attrs_mut().set_background(old_background);
+            composited_cell.attrs_mut().set_foreground(old_foreground);
+        }
+
+        let mut opaque = crate::opaque_cell::OpaqueCell::new(composited_cell, None, opacity);
+        opaque.blend_all(cell_above);
+    }
+
+    /// Automatically adjust text contrast.
+    pub fn auto_text_contrast(
+        composited_cell: &mut termwiz::cell::Cell,
+        target_text_contrast: f32,
+        apply_to_readable_text_only: bool,
+    ) {
+        let mut opaque = crate::opaque_cell::OpaqueCell::new(composited_cell, None, 1.0);
+        opaque.ensure_readable_contrast(target_text_contrast, apply_to_readable_text_only);
+    }
+
+    /// Add a little indicator in the top-right to show that Tattoy is running.
+    pub fn add_indicator(
+        cells: &mut [&mut [termwiz::cell::Cell]],
+        indicator_cell: &termwiz::cell::Cell,
+        x: usize,
+        y: usize,
+    ) -> Result<()> {
+        let composited_cell = Self::get_cell_mut(cells, x, y)?;
+        Self::composite_cells(composited_cell, indicator_cell, 1.0);
+
+        Ok(())
+    }
+}

--- a/crates/tattoy/src/config/main.rs
+++ b/crates/tattoy/src/config/main.rs
@@ -135,6 +135,8 @@ pub(crate) struct TextContrast {
     pub enabled: bool,
     /// The target contrast
     pub target_contrast: f32,
+    /// Whether to adjust the contrast for readable text only, or all text.
+    pub apply_to_readable_text_only: bool,
 }
 
 impl Default for TextContrast {
@@ -142,6 +144,7 @@ impl Default for TextContrast {
         Self {
             enabled: true,
             target_contrast: 2.0,
+            apply_to_readable_text_only: true,
         }
     }
 }

--- a/crates/tattoy/src/main.rs
+++ b/crates/tattoy/src/main.rs
@@ -10,6 +10,7 @@ pub mod config {
     pub mod input;
     pub mod main;
 }
+pub mod compositor;
 pub mod loader;
 pub mod opaque_cell;
 pub mod raw_input;
@@ -42,6 +43,7 @@ pub mod tattoys {
     /// Shadertoy-like shaders
     pub mod shaders {
         pub mod gpu;
+        pub mod ichannel;
         pub mod main;
     }
 }

--- a/crates/tattoy/src/opaque_cell.rs
+++ b/crates/tattoy/src/opaque_cell.rs
@@ -131,7 +131,21 @@ impl<'cell> OpaqueCell<'cell> {
 
     /// Ensure that the colour difference between the background and foreground is sufficient
     /// enough to be readable.
-    pub fn ensure_readable_contrast(&mut self, target_contrast: f32) {
+    pub fn ensure_readable_contrast(
+        &mut self,
+        target_contrast: f32,
+        apply_to_readable_text_only: bool,
+    ) {
+        // TODO:
+        // * Check that the colour is from the terminal palette.
+        if apply_to_readable_text_only && !self.cell.str().chars().all(char::is_alphanumeric) {
+            return;
+        }
+
+        if self.cell.str() == "▀" || self.cell.str() == "▄" {
+            return;
+        }
+
         // I think these default colours are only assigned for the very first composited layer?
         let fg_raw =
             Self::extract_colour(self.cell.attrs().foreground()).unwrap_or(self.default_colour);

--- a/crates/tattoy/src/tattoys/shaders/header.glsl
+++ b/crates/tattoy/src/tattoys/shaders/header.glsl
@@ -9,3 +9,23 @@ layout(binding = 0) uniform Variables
   float iTime;
   int   iFrame;
 };
+
+layout(binding = 1) uniform texture2D iChannelTexture;
+layout(binding = 2) uniform sampler iChannel0;
+
+#define textureSampler texture
+#define textureSamplerLod textureLod
+
+vec4 iChannel1 = iChannel0;
+
+vec4 textureSampler(sampler iChannelSampler, vec2 coords) {
+	return texture(sampler2D(iChannelTexture, iChannelSampler), coords);
+}
+
+vec4 textureSampler(sampler iChannelSampler, vec2 coords, float bias) {
+	return texture(sampler2D(iChannelTexture, iChannelSampler), coords, bias);
+}
+
+vec4 textureSamplerLod(sampler iChannelSampler, vec2 coords, float lod) {
+	return textureLod(sampler2D(iChannelTexture, iChannelSampler), coords, lod);
+}

--- a/crates/tattoy/src/tattoys/shaders/ichannel.rs
+++ b/crates/tattoy/src/tattoys/shaders/ichannel.rs
@@ -1,0 +1,74 @@
+//! Support for the Shader Toy convention of a `iChannel0` buffer. In our case it typically
+//! contains a pixel representation of the TTY.
+
+impl super::gpu::GPU<'_> {
+    /// Update the GPU with the current state of the terminal as RGB values.
+    pub fn update_ichannel_texture_data(&self, image_data: &image::RgbaImage) {
+        let tty_image_width = image_data.dimensions().0;
+        let tty_image_height = image_data.dimensions().1;
+        let output_image_size = self.get_image_size();
+        if tty_image_width != u32::from(output_image_size.0)
+            || tty_image_height != u32::from(output_image_size.1)
+        {
+            return;
+        }
+
+        tracing::debug!("Updating GPU with new TTY image data: {}", image_data.len());
+        self.queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.ichannel_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            image_data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(4 * tty_image_width),
+                rows_per_image: Some(tty_image_height),
+            },
+            wgpu::Extent3d {
+                width: tty_image_width,
+                height: tty_image_height,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
+    /// Recreate the iChannel texture. Most likely occurs when the user's terminal resizes.
+    pub fn recreate_ichannel_texture(&mut self) {
+        tracing::debug!(
+            "Recreating iChannel texture with size: {:?}",
+            self.variables.iResolution
+        );
+
+        let image_size = self.get_image_size();
+        self.ichannel_texture = self
+            .device
+            .create_texture(&Self::ichannel_texture_descriptor(
+                image_size.0,
+                image_size.1,
+            ));
+    }
+
+    /// The texture descriptor for the iChannel texture.
+    pub fn ichannel_texture_descriptor(
+        width: u16,
+        height: u16,
+    ) -> wgpu::TextureDescriptor<'static> {
+        wgpu::TextureDescriptor {
+            size: wgpu::Extent3d {
+                width: width.into(),
+                height: height.into(),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            label: Some("ichannel_texture"),
+            view_formats: &[],
+        }
+    }
+}

--- a/crates/tattoy/src/tattoys/tattoyer.rs
+++ b/crates/tattoy/src/tattoys/tattoyer.rs
@@ -1,6 +1,6 @@
 //! Shared state and behaviour useful to all tattoys.#
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{ContextCompat as _, Result};
 
 /// Shared state and behaviour useful to all tattoys.
 pub(crate) struct Tattoyer {
@@ -257,5 +257,69 @@ impl Tattoyer {
         }
 
         None
+    }
+
+    /// Convert the PTY's contents to a pixel image representation.
+    pub fn convert_pty_to_pixel_image(
+        &mut self,
+        kind: &shadow_terminal::output::SurfaceKind,
+    ) -> Result<image::DynamicImage> {
+        let pixels_per_line = 2;
+
+        let surface = match kind {
+            shadow_terminal::output::SurfaceKind::Scrollback => &mut self.scrollback.surface,
+            shadow_terminal::output::SurfaceKind::Screen => &mut self.screen.surface,
+            _ => {
+                color_eyre::eyre::bail!("Unkown surface kind: {kind:?}");
+            }
+        };
+        let surface_width = surface.dimensions().0;
+        let surface_height = surface.dimensions().1;
+
+        tracing::trace!(
+            "Converting PTY of {kind:?} to a pixels, size: {}x{}. Sample content:\n{:.200}\n...",
+            surface_width,
+            surface_height,
+            surface.screen_chars_to_string()
+        );
+
+        let mut image = image::DynamicImage::new_rgba8(
+            surface_width.try_into()?,
+            (surface_height * pixels_per_line).try_into()?,
+        );
+        let image_buffer = image
+            .as_mut_rgba8()
+            .context("Couldn't get mutable reference to scrollback image")?;
+
+        let cells = &surface.screen_cells();
+        for (x, y, pixel) in image_buffer.enumerate_pixels_mut() {
+            let line = cells
+                .get(usize::try_from(y)?.div_euclid(pixels_per_line))
+                .context("Couldn't get surface line")?;
+
+            let cell = &line
+                .get(usize::try_from(x)?)
+                .context("Couldn't get surface cell from line")?;
+
+            let cell_colour = if cell.str() == " " {
+                crate::opaque_cell::OpaqueCell::extract_colour(cell.attrs().background())
+                    .map_or(crate::opaque_cell::DEFAULT_COLOUR, |background_colour| {
+                        background_colour
+                    })
+            } else {
+                let maybe_colour =
+                    crate::opaque_cell::OpaqueCell::extract_colour(cell.attrs().foreground());
+
+                if let Some(colour) = maybe_colour {
+                    colour
+                } else {
+                    color_eyre::eyre::bail!("Using Minimap without a parsed palette");
+                }
+            };
+
+            *pixel = image::Rgba(cell_colour.to_srgb_u8().into());
+        }
+
+        Ok(image)
     }
 }


### PR DESCRIPTION
This, amongst other things, enables Ghostty support.

Also:
* New config options:
  * `text.apply_to_readable_text_only`
  * `shader.render`
  * `shader.upload_tty_as_pixels`
  * `shader.render_shader_colours_to_text`
* Refactored out a `Compositor` implementation