### PR TITLE
fix: list initialised systems in shared state

### DIFF
--- a/crates/tattoy/src/loader.rs
+++ b/crates/tattoy/src/loader.rs
@@ -16,7 +16,7 @@ pub(crate) fn start_tattoys(
     let tokio_runtime = tokio::runtime::Handle::current();
     std::thread::spawn(move || -> Result<()> {
         tokio_runtime.block_on(async {
-            crate::run::wait_for_system(state.protocol_tx.subscribe(), "renderer").await;
+            crate::run::wait_for_system(&state, "renderer").await;
 
             let palette = crate::config::main::Config::load_palette(Arc::clone(&state)).await?;
             let mut tattoy_futures = tokio::task::JoinSet::new();
@@ -41,7 +41,7 @@ pub(crate) fn start_tattoys(
                     Arc::clone(&state),
                     palette.clone(),
                 ));
-                crate::run::wait_for_system(state.protocol_tx.subscribe(), "notifications").await;
+                crate::run::wait_for_system(&state, "notifications").await;
             }
 
             tracing::info!("Starting 'scrollbar' tattoy...");

--- a/crates/tattoy/src/shared_state.rs
+++ b/crates/tattoy/src/shared_state.rs
@@ -26,6 +26,8 @@ pub struct TTYSize {
 pub(crate) struct SharedState {
     /// The channel on which all Tattoy protocol messages are sent.
     pub protocol_tx: tokio::sync::broadcast::Sender<crate::run::Protocol>,
+    /// List of asynchronous systems that have initialsed.
+    pub initialised_systems: tokio::sync::RwLock<Vec<String>>,
     /// Location of the config directory.
     pub config_path: tokio::sync::RwLock<std::path::PathBuf>,
     /// Name of the main config file.
@@ -70,6 +72,7 @@ impl SharedState {
     ) -> Result<Arc<Self>> {
         let state = Self {
             protocol_tx,
+            initialised_systems: RwLock::default(),
             config_path: RwLock::default(),
             main_config_file: RwLock::default(),
             config: RwLock::default(),

--- a/crates/tattoy/src/tattoys/notifications/main.rs
+++ b/crates/tattoy/src/tattoys/notifications/main.rs
@@ -61,13 +61,11 @@ impl Notifications {
         let mut protocol = state.protocol_tx.subscribe();
         let mut notifications = Self::new(output, std::sync::Arc::clone(&state), palette).await?;
 
-        // We sleep here because of a race condition, where the message can be sent before we start
-        // listening for it. We should probably switch to using oneshot channels for system
-        // initialisation messages.
-        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
         state
-            .protocol_tx
-            .send(crate::run::Protocol::Initialised("notifications".into()))?;
+            .initialised_systems
+            .write()
+            .await
+            .push("notifications".to_owned());
 
         #[expect(
             clippy::integer_division_remainder_used,

--- a/crates/tattoy/src/tattoys/notifications/message.rs
+++ b/crates/tattoy/src/tattoys/notifications/message.rs
@@ -47,7 +47,7 @@ impl Message {
     pub const fn colour(&self) -> crate::surface::Colour {
         match self.level {
             Level::Error => (0.3, 0.0, 0.0, 1.0),
-            Level::Warn => (0.0, 0.3, 1.0, 1.0),
+            Level::Warn => (0.3, 0.3, 0.0, 1.0),
             Level::Info => (0.0, 0.3, 0.0, 1.0),
             Level::Debug => (0.0, 0.0, 0.3, 1.0),
             Level::Trace => (0.3, 0.3, 0.3, 1.0),


### PR DESCRIPTION
This avoids race conditions at startup that can lead to freezes of tattoys not starting.