### PR TITLE
feat: provide a flake.nix to build with Nix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,3 +97,13 @@ jobs:
         run: cargo shear
       - name: Verify Minimum Stable Rust Version
         run: cargo msrv verify --path crates/tattoy
+
+  nix:
+    name: "Build with Nix ❄️"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: cachix/install-nix-action@v31
+      - uses: actions/checkout@v4
+      - name: Build flake.nix
+        run: nix build

--- a/crates/tests/resources/bad_plugin.sh
+++ b/crates/tests/resources/bad_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 echo "Something went wrong" >&2
 echo "But in a good way" >&2

--- a/crates/tests/resources/print_low_contrast_samples.sh
+++ b/crates/tests/resources/print_low_contrast_samples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function bg() {
 	printf "\033[48;2;%d;%d;%dm" $1 $2 $3

--- a/ctl.sh
+++ b/ctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PROJECT_ROOT=$(dirname "$(readlink -f "$0")")
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Read version from Cargo.toml
+        cargoToml = builtins.fromTOML (builtins.readFile ./crates/tattoy/Cargo.toml);
+        version = cargoToml.package.version;
+
+        nativeBuildInputs = with pkgs; [
+          rustc
+          cargo
+          pkg-config
+        ];
+        buildInputs = with pkgs; [
+          dbus
+          xorg.libxcb
+        ];
+        checkInputs = with pkgs; [
+          bash
+          nano
+          procps
+          cargo-nextest
+          mesa.llvmpipeHook
+        ];
+
+        tattoy = pkgs.rustPlatform.buildRustPackage {
+          pname = "tattoy";
+          inherit version;
+
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          useNextest = true;
+          preCheck = "cargo build --all";
+
+          inherit nativeBuildInputs buildInputs checkInputs;
+
+          meta = with pkgs.lib; {
+            description = "Text-based compositor for modern terminals";
+            homepage = "https://tattoy.sh";
+            license = licenses.mit;
+            maintainers = with maintainers; [ vincentbernat ];
+            platforms = platforms.linux;
+          };
+        };
+      in
+      {
+        packages = {
+          default = tattoy;
+          tattoy = tattoy;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs nativeBuildInputs checkInputs;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${tattoy}/bin/tattoy";
+        };
+      });
+}


### PR DESCRIPTION
One can use `nix build .`.

Unfortunately, it does not work as one of the dependency is referencing a file from another workspace and I lack any experience with Rust or Nix packaging for Rust, so I don't know how to fix that.

Also, I made it Linux-only, but it would be possible to add support for MacOS.

This would help for #100.